### PR TITLE
Fix _last_executed exception

### DIFF
--- a/readonly/__init__.py
+++ b/readonly/__init__.py
@@ -46,6 +46,7 @@ class ReadOnlyCursorWrapper(object):
         # Data Manipulation
         'INSERT INTO', 'UPDATE', 'REPLACE', 'DELETE FROM',
     )
+    _last_executed = ''
 
     def __init__(self, cursor):
         self.cursor = cursor


### PR DESCRIPTION
I was getting the following exception on POST:

'Cursor' object has no attribute '_last_executed'

adding _last_executed as an empty string works for me
