### PR TITLE
Fix monkey patching in Django 1.7 and newer

### DIFF
--- a/readonly/__init__.py
+++ b/readonly/__init__.py
@@ -10,8 +10,14 @@ __version__ = VERSION
 
 from time import time
 
+import django
 from django.conf import settings
-from django.db.backends import util
+
+if django.VERSION < (1, 7):
+    from django.db.backends import util
+else:
+    from django.db.backends import utils as util
+
 from django.utils.log import getLogger
 from .exceptions import DatabaseWriteDenied
 


### PR DESCRIPTION
django.db.backends.util was deprecated and replaced with django.db.backends.utils in Django 1.7.
Here we import util in Django 1.6 and older, and utils otherwise.