### PR TITLE
Add support for selective read-only db when multi-databases are used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pip-log.txt
 /example_project/local_settings.py
 /docs/html
 /docs/doctrees
+.idea

--- a/readonly/__init__.py
+++ b/readonly/__init__.py
@@ -28,6 +28,13 @@ logger = getLogger('django.db.backends')
 def _readonly():
     return getattr(settings, 'SITE_READ_ONLY', False)
 
+def _get_readonly_dbs():
+    read_on_db_names = []
+    for db_key in getattr(settings, 'DB_READ_ONLY_DATABASES', tuple()):
+        db = settings.DATABASES.get(db_key)
+        if db:
+            read_on_db_names.append(db['NAME'])
+    return read_on_db_names
 
 class ReadOnlyCursorWrapper(object):
     """
@@ -54,13 +61,15 @@ class ReadOnlyCursorWrapper(object):
     )
     _last_executed = ''
 
-    def __init__(self, cursor):
+    def __init__(self, cursor, db):
         self.cursor = cursor
+        self.db = db
         self.readonly = _readonly()
+        self.readonly_dbs = _get_readonly_dbs()
 
     def execute(self, sql, params=()):
         # Check the SQL
-        if self.readonly and self._write_sql(sql):
+        if self.readonly and self._write_sql(sql) and self._write_to_readonly_db():
             raise DatabaseWriteDenied
         return self.cursor.execute(sql, params)
 
@@ -79,10 +88,12 @@ class ReadOnlyCursorWrapper(object):
     def _write_sql(self, sql):
         return sql.startswith(self.SQL_WRITE_BLACKLIST)
 
+    def _write_to_readonly_db(self):
+        return not self.readonly_dbs or self.db.settings_dict['NAME'] in self.readonly_dbs
 
 class CursorWrapper(util.CursorWrapper):
     def __init__(self, cursor, db):
-        self.cursor = ReadOnlyCursorWrapper(cursor)
+        self.cursor = ReadOnlyCursorWrapper(cursor, db)
         self.db = db
 
 

--- a/readonly/middleware.py
+++ b/readonly/middleware.py
@@ -28,13 +28,15 @@ class DatabaseReadOnlyMiddleware(object):
                 from django.contrib import messages
                 messages.error(
                     request,
-                    'The site is currently in read-only '
-                    'mode. Please try editing later.')
+                    getattr(settings, 'DB_READ_ONLY_ERROR_MESSAGE',
+                            'The site is currently in read-only '
+                            'mode. Please try editing later.'))
 
             # Try to redirect to this page's GET version
             return HttpResponseReload(request)
         else:
             # We can't do anything about this error
             return HttpResponse(
-                'The site is currently in read-only mode. '
-                'Please try again later.')
+                getattr(settings, 'DB_READ_ONLY_ERROR_MESSAGE',
+                        'The site is currently in read-only mode. '
+                        'Please try again later.'))


### PR DESCRIPTION
It would be nice to turn on read-only mode per db when multi databases are used.