### PR TITLE
Fixing for Django 1.9.

### DIFF
--- a/readonly/__init__.py
+++ b/readonly/__init__.py
@@ -13,7 +13,7 @@ if django.VERSION < (1, 7):
     from django.db.backends import util
 else:
     from django.db.backends import utils as util
-from django.utils.log import getLogger
+from logging import getLogger
 
 from readonly.exceptions import DatabaseWriteDenied
 


### PR DESCRIPTION
Importing getLogger via django.utils.log was just importing logging.getLogger by proxy. Code changes in Django 1.9 break the import.