### PR TITLE
Adds Django 1.11 transition middleware

### DIFF
--- a/readonly/middleware.py
+++ b/readonly/middleware.py
@@ -17,7 +17,7 @@ class HttpResponseReload(HttpResponse):
         self['Location'] = iri_to_uri(referer or "/")
 
 
-class DatabaseReadOnlyMiddleware(object):
+class DatabaseReadOnlyMiddleware(django.utils.deprecation.MiddlewareMixin):
     def process_exception(self, request, exception):
         # Only process DatabaseWriteDenied exceptions
         if not isinstance(exception, DatabaseWriteDenied):


### PR DESCRIPTION
Following the Django 1.11 docs, the transition suggestion is to have the middleware class inherit their MiddlewareMixin class to transition to the new style.

Helps #14 