### PR TITLE
Allow to modify "read_only" and "readonly_dbs" on ReadOnlyCursorWrapper's constructor

### DIFF
--- a/readonly/__init__.py
+++ b/readonly/__init__.py
@@ -55,7 +55,7 @@ class ReadOnlyCursorWrapper(object):
         # Data Definition
         'CREATE', 'ALTER', 'RENAME', 'DROP', 'TRUNCATE',
         # Data Manipulation
-        'INSERT INTO', 'UPDATE', 'REPLACE', 'DELETE FROM',
+        'INSERT', 'UPDATE', 'REPLACE', 'DELETE',
     )
 
     def __init__(self, cursor, db, read_only=None, readonly_dbs=None):
@@ -91,7 +91,7 @@ class ReadOnlyCursorWrapper(object):
         return iter(self.cursor)
 
     def _write_sql(self, sql):
-        return sql.startswith(self.SQL_WRITE_BLACKLIST)
+        return any(s.strip().upper().startswith(self.SQL_WRITE_BLACKLIST) for s in sql.split(';'))
 
     def _write_to_readonly_db(self):
         return (

--- a/readonly/__init__.py
+++ b/readonly/__init__.py
@@ -94,8 +94,7 @@ class ReadOnlyCursorWrapper(object):
         return any(s.strip().upper().startswith(self.SQL_WRITE_BLACKLIST) for s in sql.split(';'))
 
     def _write_to_readonly_db(self):
-        return (
-                not self.readonly_dbs
+        return (not self.readonly_dbs
                 or self.db.settings_dict['NAME'] in self.readonly_dbs)
 
     @property


### PR DESCRIPTION
I propose to modify the constructor of `ReadOnlyCursorWrapper` to set `read_only` and `readonly_dbs` fields to add more versatility to this class (using it without setting any configuration variable on `django`). 

Also, I improved the `_write_sql()` method to make it more robust to masked write-mode sql queries.